### PR TITLE
Support Debian

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -30,8 +30,16 @@ class wireguard::install (
         include ::apt
         apt::ppa { $repo_url: }
       }
+      'Debian': {
+        include ::apt
+        apt::source { 'debian_unstable':
+          location => $repo_url,
+          release  => 'unstable',
+          pin      => 90,
+        }
+      }
       default: {
-        fail('Unsupported OS family')
+        warning("Unsupported OS family, couldn't configure package automatically")
       }
     }
   }
@@ -49,8 +57,16 @@ class wireguard::install (
         default => undef,
       }
     }
+    'Debian': {
+      $_require = $manage_repo ? {
+        true    => Apt::Source['debian_unstable'],
+        default => undef,
+      }
+    }
     default: {
-      fail('Unsupported OS family')
+      if $manage_package {
+        warning("Unsupported OS family, couldn't configure package automatically")
+      }
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,8 +17,15 @@ class wireguard::params {
       $repo_url       = 'ppa:wireguard/wireguard'
       $config_dir     = '/etc/wireguard'
     }
+    'Debian': {
+      $manage_package = true
+      $manage_repo    = true
+      $package_name   = ['wireguard', 'wireguard-dkms', 'wireguard-tools']
+      $repo_url       = 'http://deb.debian.org/debian/'
+      $config_dir     = '/etc/wireguard'
+    }
     default: {
-      fail('Unsupported OS family')
+      warning("Unsupported OS family, couldn't configure package automatically")
     }
   }
 }


### PR DESCRIPTION
According to the official Wireguard instructions, we install Wireguard
via the Debian Unstable repo, and pin at 90 priority.

We want users of other OSes to be able to use this module and manage
packages themselves, so we change the `fail` to a `warning` for
unsupported OS families.