### PR TITLE
Prevent Debian APT preferences pin misconfiguration for origin deb.debian.org

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -32,10 +32,13 @@ class wireguard::install (
       }
       'Debian': {
         include apt
+        apt::pin { 'debian_unstable':
+          release  => 'unstable',
+          priority => 90,
+        }
         apt::source { 'debian_unstable':
           location => $repo_url,
           release  => 'unstable',
-          pin      => 90,
         }
       }
       default: {

--- a/metadata.json
+++ b/metadata.json
@@ -38,7 +38,12 @@
       ]
     },
     {
-      "operatingsystem": "Debian"
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "8",
+        "9",
+        "10"
+      ]
     }
 
   ]

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -61,6 +61,7 @@ describe 'wireguard::install' do
                                       })
                 end
                 it { is_expected.to contain_class('Apt')}
+                it { is_expected.to contain_apt__pin('debian_unstable')}
                 it { is_expected.to contain_apt__source('debian_unstable')}
             end
             end


### PR DESCRIPTION
### Problem description
When using release v0.4.1 of puppet-wireguard for Debian systems there may occur APT preferences misconfigurations for other repositories also using origin deb.debian.org.
This results in a pin priority of 90 for all repositories using deb.debian.org.
Having a pin of 90 for unstable and stable repositories could lead to unexpected APT behavior.

This is caused by https://github.com/spacedog/puppet-wireguard/blob/master/manifests/install.pp#L38 which only sets an integer value for the pin parameter of apt::source.
An integer pin instructs https://github.com/puppetlabs/puppetlabs-apt/blob/master/manifests/source.pp#L130 to set the pin origin to the host name from the repository URL, which is then set in the APT preferences file by https://github.com/puppetlabs/puppetlabs-apt/blob/master/templates/pin.pref.epp#L17 affecting other repositories.

To fix this, puppet-wireguard should pin packages of the unstable repository based on the release (`Pin: release a=unstable`) as recommended in https://www.wireguard.com/install/.

### Affected environment

#### Puppetfile
```
mod 'abaranov-wireguard',
  :git => 'https://github.com/spacedog/puppet-wireguard',
  :tag => 'v0.4.1'
mod 'puppetlabs-apt', '7.3.0'
```

#### Node configuration
```
$ cat /etc/apt/sources.list
deb http://deb.debian.org/debian buster main non-free contrib
deb http://deb.debian.org/debian buster-updates main non-free contrib
deb http://security.debian.org/debian-security buster/updates main non-free contrib
```

### Current behaviour
```
$ cat /etc/apt/preferences.d/debian_unstable.pref 
# This file is managed by Puppet. DO NOT EDIT.
Explanation: apt: debian_unstable
Package: *
Pin: origin deb.debian.org
Pin-Priority: 90
```
```
$ apt-cache policy mariadb-server
mariadb-server:
  Installed: (none)
  Candidate: 1:10.3.21-1
  Version table:
     1:10.3.21-1 90
         90 http://deb.debian.org/debian unstable/main amd64 Packages
     1:10.3.18-0+deb10u1 90
         90 http://deb.debian.org/debian buster/main amd64 Packages
```

### Expected behaviour
```
$ cat /etc/apt/preferences.d/debian_unstable.pref 
# This file is managed by Puppet. DO NOT EDIT.
Explanation: apt: debian_unstable
Package: *
Pin: release a=unstable
Pin-Priority: 90
```
```
$ apt-cache policy mariadb-server
mariadb-server:
  Installed: (none)
  Candidate: 1:10.3.18-0+deb10u1
  Version table:
     1:10.3.21-1 90
         90 http://deb.debian.org/debian unstable/main amd64 Packages
     1:10.3.18-0+deb10u1 500
        500 http://deb.debian.org/debian buster/main amd64 Packages
```