### PR TITLE
Make 'address' parameter of wireguard::interface optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,13 +167,6 @@ Defines wireguard tunnel interfaces
 
 The following parameters are available in the `wireguard::interface` defined type.
 
-##### `address`
-
-Data type: `Variant[Array,String]`
-
-List of IP (v4 or v6) addresses (optionally with CIDR masks) to
-be assigned to the interface.
-
 ##### `private_key`
 
 Data type: `String`
@@ -193,6 +186,15 @@ Data type: `Enum['present','absent']`
 State of the interface
 
 Default value: 'present'
+
+##### `address`
+
+Data type: `Optional[Variant[Array,String]]`
+
+List of IP (v4 or v6) addresses (optionally with CIDR masks) to
+be assigned to the interface.
+
+Default value: `undef`
 
 ##### `peers`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,28 +20,28 @@
 # @param interfaces
 #   Define wireguard interfaces
 class wireguard (
-  Variant[Array, String] $package_name    = $::wireguard::params::package_name,
-  String                 $repo_url        = $::wireguard::params::repo_url,
-  Boolean                $manage_repo     = $::wireguard::params::manage_repo,
-  Boolean                $manage_package  = $::wireguard::params::manage_package,
+  Variant[Array, String] $package_name    = $wireguard::params::package_name,
+  String                 $repo_url        = $wireguard::params::repo_url,
+  Boolean                $manage_repo     = $wireguard::params::manage_repo,
+  Boolean                $manage_package  = $wireguard::params::manage_package,
   Variant[Boolean, Enum['installed','latest','present']] $package_ensure = 'installed',
-  Stdlib::Absolutepath   $config_dir      = $::wireguard::params::config_dir,
-  String                 $config_dir_mode = $::wireguard::params::config_dir_mode,
+  Stdlib::Absolutepath   $config_dir      = $wireguard::params::config_dir,
+  String                 $config_dir_mode = $wireguard::params::config_dir_mode,
   Optional[Hash]         $interfaces      = {},
-) inherits ::wireguard::params {
+) inherits wireguard::params {
 
-  class { '::wireguard::install':
+  class { 'wireguard::install':
     package_name   => $package_name,
     package_ensure => $package_ensure,
     repo_url       => $repo_url,
     manage_repo    => $manage_repo,
     manage_package => $manage_package,
   }
-  -> class { '::wireguard::config':
+  -> class { 'wireguard::config':
     config_dir      => $config_dir,
     config_dir_mode => $config_dir_mode,
   }
-  -> Class[::wireguard]
+  -> Class[wireguard]
 
   $interfaces.each |$name, $options| {
     wireguard::interface { $name:

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -27,11 +27,11 @@ class wireguard::install (
         }
       }
       'Ubuntu': {
-        include ::apt
+        include apt
         apt::ppa { $repo_url: }
       }
       'Debian': {
-        include ::apt
+        include apt
         apt::source { 'debian_unstable':
           location => $repo_url,
           release  => 'unstable',

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -1,14 +1,14 @@
 # @summary
 #   Defines wireguard tunnel interfaces
-# @param address
-#   List of IP (v4 or v6) addresses (optionally with CIDR masks) to
-#   be assigned to the interface.
 # @param private_key
 #   Private key for data encryption
 # @param listen_port
 #   The port to listen
 # @param ensure
 #   State of the interface
+# @param address
+#   List of IP (v4 or v6) addresses (optionally with CIDR masks) to
+#   be assigned to the interface.
 # @param peers
 #   List of peers for wireguard interface
 # @param saveconfig
@@ -16,10 +16,10 @@
 # @param config_dir
 #   Path to wireguard configuration files
 define wireguard::interface (
-  Variant[Array,String] $address,
-  String                $private_key,
-  Integer[1,65535]      $listen_port,
-  Enum['present','absent'] $ensure = 'present',
+  String                          $private_key,
+  Integer[1,65535]                $listen_port,
+  Enum['present','absent']        $ensure  = 'present',
+  Optional[Variant[Array,String]] $address = undef,
   Optional[Array[Struct[
     {
       'PublicKey'           => String,

--- a/spec/defines/interface_spec.rb
+++ b/spec/defines/interface_spec.rb
@@ -74,6 +74,16 @@ PresharedKey = output_from_wg_genpsk
           })
           end
         end
+        context 'wireguard::interface define without an address' do
+          let (:params) do
+            default_params.reject { |key, _| key == 'address' }
+          end
+          it { is_expected.to compile.with_all_deps }
+          it do
+            is_expected.to contain_file('/etc/wireguard/wg0.conf')
+              .without_content(%r{Address})
+          end
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,5 +16,17 @@ SimpleCov.start do
 end
 
 RSpec.configure do |c|
+  # getting the correct facter version is tricky. We use facterdb as a source to mock facts
+  # see https://github.com/camptocamp/facterdb
+  # people might provide a specific facter version. In that case we use it.
+  # Otherwise we need to match the correct facter version to the used puppet version.
+  # as of 2019-10-31, puppet 5 ships facter 3.11 and puppet 6 ships facter 3.14
+  # https://puppet.com/docs/puppet/5.5/about_agent.html
+  c.default_facter_version = if ENV['FACTERDB_FACTS_VERSION']
+                               ENV['FACTERDB_FACTS_VERSION']
+                             else
+                               Gem::Dependency.new('', ENV['PUPPET_VERSION']).match?('', '5') ? '3.11.0' : '3.14.0'
+                             end
+
   c.hiera_config = File.expand_path(File.join(__FILE__, '../fixtures/hiera.yaml'))
 end

--- a/templates/interface.conf.erb
+++ b/templates/interface.conf.erb
@@ -1,11 +1,13 @@
 # This file is managed by puppet
 [Interface]
-<% if @address.is_a? Array -%>
+<%- if @address -%>
+  <%- if @address.is_a? Array -%>
     <%- @address.flatten.each do |adr| -%>
 Address = <%= adr %>
     <%- end -%>
-<%- else -%>
+  <%- else -%>
 Address = <%= @address %>
+  <%- end -%>
 <%- end -%>
 <% if @saveconfig -%>
 SaveConfig = true


### PR DESCRIPTION
This allows to create wireguard interfaces without an explicit IP address.

I've also fixed some style issue regarding the absolute name `$::` referencing of classes/parameters. This isn't needed anymore with Puppet 4.