### PR TITLE
support setting DNS servers for wireguard interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,14 @@ be assigned to the interface.
 
 Default value: `undef`
 
+##### `dns`
+
+Data: type: `Optional[String]`
+
+List of IP (v4 or v6) addresses of DNS servers to use
+
+Default value: `undef`
+
 ##### `peers`
 
 Data type: `Optional[Array[Struct[
@@ -227,4 +235,3 @@ Data type: `Stdlib::Absolutepath`
 Path to wireguard configuration files
 
 Default value: '/etc/wireguard'
-

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -9,6 +9,8 @@
 # @param address
 #   List of IP (v4 or v6) addresses (optionally with CIDR masks) to
 #   be assigned to the interface.
+# @param dns
+#   List of IP (v4 or v6) addresses of DNS servers to use
 # @param peers
 #   List of peers for wireguard interface
 # @param saveconfig
@@ -20,6 +22,7 @@ define wireguard::interface (
   Integer[1,65535]                $listen_port,
   Enum['present','absent']        $ensure  = 'present',
   Optional[Variant[Array,String]] $address = undef,
+  Optional[String]                $dns = undef,
   Optional[Array[Struct[
     {
       'PublicKey'           => String,

--- a/spec/defines/interface_spec.rb
+++ b/spec/defines/interface_spec.rb
@@ -9,6 +9,7 @@ describe 'wireguard::interface', :type => :define do
         '1.1.1.1/24',
         '2.2.2.2/24'
       ],
+      'dns'         => '1.1.1.1',
       'private_key' => 'privatekey',
       'listen_port' => 52980,
       'ensure'      => 'present',
@@ -58,6 +59,7 @@ Address = 2.2.2.2/24
 SaveConfig = true
 PrivateKey = privatekey
 ListenPort = 52980
+DNS = 1.1.1.1
 
 # Peers
 [Peer]
@@ -96,7 +98,7 @@ PresharedKey = output_from_wg_genpsk
           :operatingsystem => 'Nexenta',
         }
       end
-      it do 
+      it do
         expect { should compile.with_all_deps }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
       end
     end

--- a/templates/interface.conf.erb
+++ b/templates/interface.conf.erb
@@ -14,6 +14,9 @@ SaveConfig = true
 <% end -%>
 PrivateKey = <%= @private_key %>
 ListenPort = <%= @listen_port %>
+<% if @dns -%>
+DNS = <%= @dns %>
+<% end -%>
 <%- if @peers -%>
 
 # Peers


### PR DESCRIPTION
When using Wireguard on a "client" machine it can be useful to set the DNS servers option in the interface configuration file.