### PR TITLE
Add support for arrays for PreUp, PostUp, PreDown and PostDown interface config

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,30 @@ be assigned to the interface.
 
 Default value: `undef`
 
+##### `preup`
+
+Data type: `Optional[Variant[Array,String]]`
+
+List of commands to execute before the interface is brought up
+
+##### `postup`
+
+Data type: `Optional[Variant[Array,String]]`
+
+List of commands to execute after the interface is brought up
+
+##### `predown`
+
+Data type: `Optional[Variant[Array,String]]`
+
+List of commands to execute before the interface is taken down
+
+##### `postdown`
+
+Data type: `Optional[Variant[Array,String]]`
+
+List of commands to execute after the interface is taken down
+
 ##### `peers`
 
 Data type: `Optional[Array[Struct[

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -9,6 +9,14 @@
 # @param address
 #   List of IP (v4 or v6) addresses (optionally with CIDR masks) to
 #   be assigned to the interface.
+# @param preup
+#   List of commands to run before the interface is brought up
+# @param postup
+#   List of commands to run after the interface is brought up
+# @param predown
+#   List of commands to run before the interface is taken down
+# @param postup
+#   List of commands to run after the interface is taken down
 # @param peers
 #   List of peers for wireguard interface
 # @param saveconfig
@@ -18,8 +26,12 @@
 define wireguard::interface (
   String                          $private_key,
   Integer[1,65535]                $listen_port,
-  Enum['present','absent']        $ensure  = 'present',
-  Optional[Variant[Array,String]] $address = undef,
+  Enum['present','absent']        $ensure   = 'present',
+  Optional[Variant[Array,String]] $address  = undef,
+  Optional[Variant[Array,String]] $preup    = undef,
+  Optional[Variant[Array,String]] $postup   = undef,
+  Optional[Variant[Array,String]] $predown  = undef,
+  Optional[Variant[Array,String]] $postdown = undef,
   Optional[Array[Struct[
     {
       'PublicKey'           => String,

--- a/spec/defines/interface_spec.rb
+++ b/spec/defines/interface_spec.rb
@@ -12,6 +12,11 @@ describe 'wireguard::interface', :type => :define do
       'private_key' => 'privatekey',
       'listen_port' => 52980,
       'ensure'      => 'present',
+      'postup'      => [
+          'foo',
+          'bar',
+      ],
+      'postdown'    => 'baz',
       'peers'       => [
         {
           'PublicKey'  => 'publickey1',
@@ -58,6 +63,9 @@ Address = 2.2.2.2/24
 SaveConfig = true
 PrivateKey = privatekey
 ListenPort = 52980
+PostUp = foo
+PostUp = bar
+PostDown = baz
 
 # Peers
 [Peer]

--- a/templates/interface.conf.erb
+++ b/templates/interface.conf.erb
@@ -14,6 +14,42 @@ SaveConfig = true
 <% end -%>
 PrivateKey = <%= @private_key %>
 ListenPort = <%= @listen_port %>
+<%- if @preup -%>
+  <%- if @preup.is_a? Array -%>
+    <%- @preup.flatten.each do |p| -%>
+PreUp = <%= p %>
+    <%- end -%>
+  <%- else -%>
+PreUp = <%= @preup %>
+  <%- end -%>
+<%- end -%>
+<%- if @postup -%>
+  <%- if @postup.is_a? Array -%>
+    <%- @postup.flatten.each do |p| -%>
+PostUp = <%= p %>
+    <%- end -%>
+  <%- else -%>
+PostUp = <%= @postup %>
+  <%- end -%>
+<%- end -%>
+<%- if @predown -%>
+  <%- if @predown.is_a? Array -%>
+    <%- @predown.flatten.each do |p| -%>
+PreDown = <%= p %>
+    <%- end -%>
+  <%- else -%>
+PreDown = <%= @predown %>
+  <%- end -%>
+<%- end -%>
+<%- if @postdown -%>
+  <%- if @postdown.is_a? Array -%>
+    <%- @postdown.flatten.each do |p| -%>
+PostDown = <%= p %>
+    <%- end -%>
+  <%- else -%>
+PostDown = <%= @postdown %>
+  <%- end -%>
+<%- end -%>
 <%- if @peers -%>
 
 # Peers


### PR DESCRIPTION
This commit adds support for the pre and post up and down commands
supported by wg-quick.

This commit differs to other PRs as it supports either a string,
or an array of commands if more than one is required.