### PR TITLE
add Comment parameter to peers

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Data type: `Optional[Array[Struct[
       'Endpoint'            => Optional[String],
       'PersistentKeepalive' => Optional[Integer],
       'PresharedKey'        => Optional[String],
+      'Comment'             => Optional[String],
     }
   ]]]`
 

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -27,6 +27,7 @@ define wireguard::interface (
       'Endpoint'            => Optional[String],
       'PersistentKeepalive' => Optional[Integer],
       'PresharedKey'        => Optional[String],
+      'Comment'             => Optional[String],
     }
   ]]]                   $peers        = [],
   Boolean               $saveconfig   = true,

--- a/spec/defines/interface_spec.rb
+++ b/spec/defines/interface_spec.rb
@@ -14,6 +14,7 @@ describe 'wireguard::interface', :type => :define do
       'ensure'      => 'present',
       'peers'       => [
         {
+          'Comment'    => 'foo',
           'PublicKey'  => 'publickey1',
           'AllowedIPs' => '1.1.1.2',
         },
@@ -21,7 +22,8 @@ describe 'wireguard::interface', :type => :define do
           'PublicKey'    => 'publickey2',
           'AllowedIPs'   => '1.1.1.3',
           'Endpoint'     => '3.3.3.3:12345',
-          'PresharedKey' => 'output_from_wg_genpsk'
+          'PresharedKey' => 'output_from_wg_genpsk',
+          'Comment'      => 'bar baz',
         },
       ],
       'saveconfig'  => true,
@@ -61,6 +63,7 @@ ListenPort = 52980
 
 # Peers
 [Peer]
+# foo
 PublicKey = publickey1
 AllowedIPs = 1.1.1.2
 
@@ -69,6 +72,7 @@ PublicKey = publickey2
 AllowedIPs = 1.1.1.3
 Endpoint = 3.3.3.3:12345
 PresharedKey = output_from_wg_genpsk
+# bar baz
 
 '
           })

--- a/templates/interface.conf.erb
+++ b/templates/interface.conf.erb
@@ -20,7 +20,11 @@ ListenPort = <%= @listen_port %>
     <%- @peers.each do |peer| -%>
 [Peer]
         <%- peer.each do |key,value| -%>
+          <%- if key == 'Comment' -%>
+# <%= value %>
+          <%- else -%>
 <%= key %> = <%= value %>
+          <%- end -%>
         <%- end %>
     <%- end -%>
 <%- end -%>


### PR DESCRIPTION
This PR will allow to add a comment for each Peer

As a (desired) side effect, this will make the use of the Friendly names with the [MindFlavor's prometheus exporter](https://github.com/MindFlavor/prometheus_wireguard_exporter#friendly-names) easier.
