### PR TITLE
added option to purge config dir

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,12 +7,25 @@
 class wireguard::config (
   Stdlib::Absolutepath $config_dir,
   String               $config_dir_mode,
+  Boolean              $config_dir_purge,
 ) {
 
-  file {$config_dir:
-    ensure => 'directory',
-    mode   => $config_dir_mode,
-    owner  => 'root',
-    group  => 'root',
+  if $config_dir_purge {
+    file {$config_dir:
+      ensure  => 'directory',
+      mode    => $config_dir_mode,
+      owner   => 'root',
+      group   => 'root',
+      force   => true,
+      recurse => true,
+      purge   => true,
+    }
+  } else {
+    file {$config_dir:
+      ensure => 'directory',
+      mode   => $config_dir_mode,
+      owner  => 'root',
+      group  => 'root',
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,14 +20,15 @@
 # @param interfaces
 #   Define wireguard interfaces
 class wireguard (
-  Variant[Array, String] $package_name    = $wireguard::params::package_name,
-  String                 $repo_url        = $wireguard::params::repo_url,
-  Boolean                $manage_repo     = $wireguard::params::manage_repo,
-  Boolean                $manage_package  = $wireguard::params::manage_package,
+  Variant[Array, String] $package_name     = $wireguard::params::package_name,
+  String                 $repo_url         = $wireguard::params::repo_url,
+  Boolean                $manage_repo      = $wireguard::params::manage_repo,
+  Boolean                $manage_package   = $wireguard::params::manage_package,
   Variant[Boolean, Enum['installed','latest','present']] $package_ensure = 'installed',
-  Stdlib::Absolutepath   $config_dir      = $wireguard::params::config_dir,
-  String                 $config_dir_mode = $wireguard::params::config_dir_mode,
-  Optional[Hash]         $interfaces      = {},
+  Stdlib::Absolutepath   $config_dir       = $wireguard::params::config_dir,
+  String                 $config_dir_mode  = $wireguard::params::config_dir_mode,
+  Boolean                $config_dir_purge = $wireguard::params::config_dir_purge,
+  Optional[Hash]         $interfaces       = {},
 ) inherits wireguard::params {
 
   class { 'wireguard::install':
@@ -38,8 +39,9 @@ class wireguard (
     manage_package => $manage_package,
   }
   -> class { 'wireguard::config':
-    config_dir      => $config_dir,
-    config_dir_mode => $config_dir_mode,
+    config_dir       => $config_dir,
+    config_dir_mode  => $config_dir_mode,
+    config_dir_purge => $config_dir_purge,
   }
   -> Class[wireguard]
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,6 +2,7 @@
 #  Class that contains OS specific parameters for other classes
 class wireguard::params {
   $config_dir_mode    = '0700'
+  $config_dir_purge   = false
   case $facts['os']['name'] {
     'RedHat', 'CentOS', 'VirtuozzoLinux': {
       $manage_package = true

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -3,8 +3,9 @@ require 'spec_helper'
 describe 'wireguard::config' do
   let :default_params do
     {
-      'config_dir'      => '/etc/wireguard',
-      'config_dir_mode' => '0700'
+      'config_dir'       => '/etc/wireguard',
+      'config_dir_mode'  => '0700'
+      'config_dir_purge' => false
     }
   end
   context 'supported operating systems' do


### PR DESCRIPTION
This PR adds the option to purge all wireguard config files that are not managed by puppet.
This is useful for example when a user renames an interface in puppet. Until now the old config would not be deleted.