### PR TITLE
Ubuntu 20.04 support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,10 +12,20 @@ class wireguard::params {
     }
     'Ubuntu': {
       $manage_package = true
-      $manage_repo    = true
-      $package_name   = ['wireguard', 'wireguard-dkms', 'wireguard-tools']
-      $repo_url       = 'ppa:wireguard/wireguard'
       $config_dir     = '/etc/wireguard'
+
+      case $facts['os']['release']['full'] {
+        '20.04': {
+          $manage_repo  = false
+          $package_name = ['wireguard-tools']
+          $repo_url     = ''
+        }
+        default: {
+          $manage_repo  = true
+          $package_name = ['wireguard', 'wireguard-dkms', 'wireguard-tools']
+          $repo_url     = 'ppa:wireguard/wireguard'
+        }
+      }
     }
     'Debian': {
       $manage_package = true


### PR DESCRIPTION
Ubuntu 20.04 has built-in support for wireguard - only need to install the wireguard-tools package.