### PR TITLE
Support specifying DNS servers for wireguard interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,14 @@ List of peers for wireguard interface
 
 Default value: []
 
+##### `dns`
+
+Data type: `Optional[String]`
+
+List of IP (v4 or v6) addresses of DNS servers to use
+
+Default value: `undef`
+
 ##### `saveconfig`
 
 Data type: `Boolean`
@@ -274,4 +282,3 @@ Data type: `Optional[Variant[Array,String]]`
 
 
 Default value: `undef`
-

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -21,6 +21,8 @@
 #   List of commands to run after the interface is taken down
 # @param peers
 #   List of peers for wireguard interface
+# @param dns
+#   List of IP (v4 or v6) addresses of DNS servers to use
 # @param saveconfig
 #    save current state of the interface upon shutdown
 # @param config_dir
@@ -45,6 +47,7 @@ define wireguard::interface (
       'Comment'             => Optional[String],
     }
   ]]]                   $peers        = [],
+  Optional[String]      $dns          = undef,
   Boolean               $saveconfig   = true,
   Stdlib::Absolutepath  $config_dir   = '/etc/wireguard',
 ) {

--- a/spec/defines/interface_spec.rb
+++ b/spec/defines/interface_spec.rb
@@ -31,6 +31,7 @@ describe 'wireguard::interface', :type => :define do
           'Comment'      => 'bar baz',
         },
       ],
+      'dns'         => '1.1.1.1,8.8.8.8',
       'mtu'         => 123,
       'saveconfig'  => true,
       'config_dir'  => '/etc/wireguard'
@@ -67,6 +68,7 @@ SaveConfig = true
 PrivateKey = privatekey
 ListenPort = 52980
 MTU = 123
+DNS = 1.1.1.1,8.8.8.8
 PostUp = foo
 PostUp = bar
 PostDown = baz
@@ -110,7 +112,7 @@ PresharedKey = output_from_wg_genpsk
           :operatingsystem => 'Nexenta',
         }
       end
-      it do 
+      it do
         expect { should compile.with_all_deps }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
       end
     end

--- a/templates/interface.conf.erb
+++ b/templates/interface.conf.erb
@@ -17,6 +17,9 @@ ListenPort = <%= @listen_port %>
 <%- if @mtu -%>
 MTU = <%= @mtu %>
 <% end -%>
+<%- if @dns -%>
+DNS = <%= @dns %>
+<% end -%>
 <%- if @preup -%>
   <%- if @preup.is_a? Array -%>
     <%- @preup.flatten.each do |p| -%>


### PR DESCRIPTION
When using Wireguard on a "client" machine it can be useful to set the DNS servers option in the interface configuration file.

(Updated replacement for https://github.com/spacedog/puppet-wireguard/pull/24)

