### PR TITLE
Updating Ubuntu support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,20 +13,10 @@ class wireguard::params {
     }
     'Ubuntu': {
       $manage_package = true
+      $manage_repo    = false
+      $package_name   = ['wireguard']
+      $repo_url       = ''
       $config_dir     = '/etc/wireguard'
-
-      case $facts['os']['release']['full'] {
-        '20.04': {
-          $manage_repo  = false
-          $package_name = ['wireguard-tools']
-          $repo_url     = ''
-        }
-        default: {
-          $manage_repo  = true
-          $package_name = ['wireguard', 'wireguard-dkms', 'wireguard-tools']
-          $repo_url     = 'ppa:wireguard/wireguard'
-        }
-      }
     }
     'Debian': {
       $manage_package = true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,27 +3,23 @@
 class wireguard::params {
   $config_dir_mode    = '0700'
   $config_dir_purge   = false
+  $manage_package     = true
+  $config_dir         = '/etc/wireguard'
   case $facts['os']['name'] {
     'RedHat', 'CentOS', 'VirtuozzoLinux': {
-      $manage_package = true
       $manage_repo    = true
       $package_name   = ['wireguard-dkms', 'wireguard-tools']
       $repo_url       = 'https://copr.fedorainfracloud.org/coprs/jdoss/wireguard/repo/epel-7/jdoss-wireguard-epel-7.repo'
-      $config_dir     = '/etc/wireguard'
     }
     'Ubuntu': {
-      $manage_package = true
       $manage_repo    = false
       $package_name   = ['wireguard']
       $repo_url       = ''
-      $config_dir     = '/etc/wireguard'
     }
     'Debian': {
-      $manage_package = true
       $manage_repo    = true
       $package_name   = ['wireguard', 'wireguard-dkms', 'wireguard-tools']
       $repo_url       = 'http://deb.debian.org/debian/'
-      $config_dir     = '/etc/wireguard'
     }
     default: {
       warning("Unsupported OS family, couldn't configure package automatically")


### PR DESCRIPTION
As suggested by @Azylog in #34, Ubuntu solved this dependency resolution by clever dependencies:
> Hello,
> No need to check against kernel version : is the Ubuntu package, wireguard-dkms is a dependancy for the 'wireguard' (without -tools) package with an exception : when the kernel provides 'wireguard-modules' package.
> This is now true for Ubuntu 16.04+.
> 
> Reference here :
> https://packages.ubuntu.com/xenial-updates/wireguard
> and here :
> https://changelogs.ubuntu.com/changelogs/pool/universe/w/wireguard/wireguard_1.0.20200513-1~16.04.2/changelog
> 
> And there's no more ppa for Ubuntu 14.04 since this summer :
> https://lists.zx2c4.com/pipermail/wireguard/2020-July/005670.html
> 
> This simplify A LOT the configuration for Ubuntu in this module :
> 'Ubuntu': {
> $manage_package = true
> $manage_repo = false
> $package_name = ['wireguard']
> $repo_url = ''
> $config_dir = '/etc/wireguard'
> }
> 
> Don't try to manage repo and install only one package : wireguard. APT will do the rest.
> 
> Anybody could make a PR for this ? (I'm still not skilled enough for this).
> 
> Thanks

This PR therefore simplifies the Ubuntu version handling and consolidates some common configuration options.