### PR TITLE
Add Debian 11 to metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -42,7 +42,8 @@
       "operatingsystemrelease": [
         "8",
         "9",
-        "10"
+        "10",
+        "11"
       ]
     }
   ],


### PR DESCRIPTION
Support for Debian 11 was added in 72f533e3f0a0c0d5f8c2d8d5bb92408d3f952048