### PR TITLE
Fix dependency issue when disabling Wireguard

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -62,7 +62,6 @@ define wireguard::interface (
     group     => 'root',
     show_diff => false,
     content   => template("${module_name}/interface.conf.erb"),
-    notify    => Service["wg-quick@${name}.service"],
   }
 
   $_service_ensure = $ensure ? {
@@ -78,6 +77,11 @@ define wireguard::interface (
     ensure   => $_service_ensure,
     provider => 'systemd',
     enable   => $_service_enable,
-    require  => File["${config_dir}/${name}.conf"],
+  }
+
+  if $ensure == 'absent' {
+    Service["wg-quick@${name}.service"] -> File["${config_dir}/${name}.conf"]
+  } else {
+    File["${config_dir}/${name}.conf"] ~> Service["wg-quick@${name}.service"]
   }
 }


### PR DESCRIPTION
When disabling Wireguard, the config file must be purged only _after_ the service is stopped, not before. Otherwise, stopping the service fails and the interface remains, and also re-enabling the service fails, since the interface is already there. 

Fix this by flipping the order of dependencies for `absent` vs. `present`. 
