### PR TITLE
params: add support for Debian 12 with built-in WireGuard support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,7 +18,7 @@ class wireguard::params {
     }
     'Debian': {
       case $facts['os']['release']['major'] {
-        '11': {
+        '11', '12': {
           $manage_repo  = false
           $package_name = ['wireguard']
           $repo_url     = ''


### PR DESCRIPTION
Can reuse the same code branch already used for Debian 11. 